### PR TITLE
Use showNational() as home event callback

### DIFF
--- a/flood-map/main.js
+++ b/flood-map/main.js
@@ -128,17 +128,11 @@ $(window).on("resize", function () {
 });
 
 $(window).on("home", function () {
-  // No zoom adjustment when inspecting a location
-  localView = false;
-  zoomUK(getPadding());
+  showNational();
 });
 
 $(window).on("location", function (e, data) {
-  if (localView) {
-    showNational();
-  } else {
-    showLocal(e, data);
-  }
+  showLocal(e, data);
 });
 
 $.ajax({


### PR DESCRIPTION
Previously, visibility of national marker layer was not being reset when returning to national view.